### PR TITLE
Update README.textile

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -30,7 +30,7 @@ h2(#prereq). Prerequisites
 
 Ruby must be able to build C-Extensions (e.g. MRI, Rubinius, not JRuby)
 
-*ImageMagick* Version 6.4.9 or later. You can get ImageMagick from "www.imagemagick.org":http://www.imagemagick.org.
+*ImageMagick* Version 6.4.9 or later, version 7.x still not supported. You can get ImageMagick from "www.imagemagick.org":http://www.imagemagick.org.
 
 On Ubuntu, you can run:
 


### PR DESCRIPTION
Should be fair enough to advertise ImageMagic 7.x is not supported for now at rmagick to avoid more PR asking the same.